### PR TITLE
Add $concaveperjoint when required to decompiled QCs.

### DIFF
--- a/Crowbar/Core/GameModel/SourceModel2531/SourceQcFile2531.vb
+++ b/Crowbar/Core/GameModel/SourceModel2531/SourceQcFile2531.vb
@@ -836,6 +836,11 @@ Public Class SourceQcFile2531
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
 			line = vbTab
 			line += "$maxconvexpieces "
 			line += Me.thePhyFileData.theSourcePhyMaxConvexPieces.ToString()

--- a/Crowbar/Core/GameModel/SourceModel31/SourceQcFile31.vb
+++ b/Crowbar/Core/GameModel/SourceModel31/SourceQcFile31.vb
@@ -1404,7 +1404,7 @@ Public Class SourceQcFile31
 	'$assumeworldspace
 	'$automass          // baked-in as mass
 	'$concave           // done
-	'$concaveperjoint
+	'$concaveperjoint   // done
 	'$damping           // done
 	'$drag
 	'$inertia           // done
@@ -1469,6 +1469,11 @@ Public Class SourceQcFile31
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
 		End If
 
 		For i As Integer = 0 To Me.thePhyFileData.theSourcePhyPhysCollisionModels.Count - 1

--- a/Crowbar/Core/GameModel/SourceModel32/SourceQcFile32.vb
+++ b/Crowbar/Core/GameModel/SourceModel32/SourceQcFile32.vb
@@ -2865,7 +2865,7 @@ Public Class SourceQcFile32
 	'$assumeworldspace
 	'$automass          // baked-in as mass
 	'$concave           // done
-	'$concaveperjoint
+	'$concaveperjoint   // done
 	'$damping           // done
 	'$drag
 	'$inertia           // done
@@ -2917,6 +2917,11 @@ Public Class SourceQcFile32
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
 		End If
 
 		For i As Integer = 0 To Me.thePhyFileData.theSourcePhyPhysCollisionModels.Count - 1

--- a/Crowbar/Core/GameModel/SourceModel36/SourceQcFile36.vb
+++ b/Crowbar/Core/GameModel/SourceModel36/SourceQcFile36.vb
@@ -3009,6 +3009,11 @@ Public Class SourceQcFile36
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
 		End If
 
 		For i As Integer = 0 To Me.thePhyFileData.theSourcePhyPhysCollisionModels.Count - 1

--- a/Crowbar/Core/GameModel/SourceModel37/SourceQcFile37.vb
+++ b/Crowbar/Core/GameModel/SourceModel37/SourceQcFile37.vb
@@ -2934,7 +2934,7 @@ Public Class SourceQcFile37
 	'$assumeworldspace
 	'$automass          // baked-in as mass
 	'$concave           // done
-	'$concaveperjoint
+	'$concaveperjoint   // done
 	'$damping           // done
 	'$drag
 	'$inertia           // done
@@ -2999,6 +2999,11 @@ Public Class SourceQcFile37
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
 		End If
 
 		For i As Integer = 0 To Me.thePhyFileData.theSourcePhyPhysCollisionModels.Count - 1

--- a/Crowbar/Core/GameModel/SourceModel49/SourceQcFile49.vb
+++ b/Crowbar/Core/GameModel/SourceModel49/SourceQcFile49.vb
@@ -3721,7 +3721,7 @@ Public Class SourceQcFile49
 	'$assumeworldspace
 	'$automass          // baked-in as mass
 	'$concave           // done
-	'$concaveperjoint
+	'$concaveperjoint   // done
 	'$damping           // done
 	'$drag
 	'$inertia           // done
@@ -3773,6 +3773,13 @@ Public Class SourceQcFile49
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+			
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
+
 			line = vbTab
 			line += "$maxconvexpieces "
 			line += Me.thePhyFileData.theSourcePhyMaxConvexPieces.ToString()

--- a/Crowbar/Core/GameModel/SourceModel52/SourceQcFile52.vb
+++ b/Crowbar/Core/GameModel/SourceModel52/SourceQcFile52.vb
@@ -3362,7 +3362,7 @@ Public Class SourceQcFile52
 	'$assumeworldspace
 	'$automass          // baked-in as mass
 	'$concave           // done
-	'$concaveperjoint
+	'$concaveperjoint   // done
 	'$damping           // done
 	'$drag
 	'$inertia           // done
@@ -3414,6 +3414,13 @@ Public Class SourceQcFile52
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+			
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
+
 			line = vbTab
 			line += "$maxconvexpieces "
 			line += Me.thePhyFileData.theSourcePhyMaxConvexPieces.ToString()

--- a/Crowbar/Core/GameModel/SourceModel53/SourceQcFile53.vb
+++ b/Crowbar/Core/GameModel/SourceModel53/SourceQcFile53.vb
@@ -3081,7 +3081,7 @@ Public Class SourceQcFile53
 	'$assumeworldspace
 	'$automass          // baked-in as mass
 	'$concave           // done
-	'$concaveperjoint
+	'$concaveperjoint   // done
 	'$damping           // done
 	'$drag
 	'$inertia           // done
@@ -3133,6 +3133,13 @@ Public Class SourceQcFile53
 			line = vbTab
 			line += "$concave"
 			Me.theOutputFileStreamWriter.WriteLine(line)
+
+			if Not Me.thePhyFileData.theSourcePhyIsCollisionModel Then
+				line = vbTab
+				line += "$concaveperjoint"
+				Me.theOutputFileStreamWriter.WriteLine(line)
+			End If
+
 			line = vbTab
 			line += "$maxconvexpieces "
 			line += Me.thePhyFileData.theSourcePhyMaxConvexPieces.ToString()


### PR DESCRIPTION
This flag is used instead of `$concave` for `$collisionjoints` props. This way it's possible to have animated props where each bone is itself composed of multiple convex segments. I found this while recompiling some of Portal 2 (v49)'s props, but it seems to be present much earlier too. I made it add it in addition to regular `$concave`, it could probably be done by itself but just in case code checks for the regular one too at some point.