### PR TITLE
Further Titanfall/Titanfall 2 model improvements.

### DIFF
--- a/Crowbar/Core/GameModel/SourceCommon/SourceMdlFileData/SourceMdlAnimation.vb
+++ b/Crowbar/Core/GameModel/SourceCommon/SourceMdlFileData/SourceMdlAnimation.vb
@@ -62,6 +62,12 @@ Public Class SourceMdlAnimation
 	Public Const STUDIO_ANIM_DELTA As Integer = &H10
 	Public Const STUDIO_ANIM_RAWROT2 As Integer = &H20
 
+	' new to v52:
+	'#define STUDIO_ANIM_RAWSCALE	0x40 // Vector48
+	'#define STUDIO_ANIM_ANIMSCALE	0x80 // mstudioanim_valueptr_t 
+	Public Const STUDIO_ANIM_RAWSCALE As Integer = &H40
+	Public Const STUDIO_ANIM_ANIMSCALE As Integer = &H80
+
 	' MDL 53 values for flags:
 	'#define STUDIO_ANIM_DELTA_53    0x01 // this appears to be delta until proven otherwise
 	'// These work as toggles, flag enabled is raw data, flag disabled is pointers, see 'STUDIO_ANIM_READBONE_53' for exception.

--- a/Crowbar/Core/GameModel/SourceCommon/SourceMdlFileData/SourceMdlAnimation.vb
+++ b/Crowbar/Core/GameModel/SourceCommon/SourceMdlFileData/SourceMdlAnimation.vb
@@ -69,12 +69,12 @@ Public Class SourceMdlAnimation
 	'#define STUDIO_ANIM_RAWROT_53	0x04 // Quaternion48
 	'#define STUDIO_ANIM_RAWSCALE_53	0x08 // Vector48
 	'// if above flag is disabled and below is enabled there is special exceptions
-	'#define STUDIO_ANIM_READBONE_53 0x10 // read bone data if any Of the above are disabled, only observed For rotation
+	'#define STUDIO_ANIM_NOROT 0x10 
 	Public Const STUDIO_ANIM_DELTA_53 As Integer = &H1
 	Public Const STUDIO_ANIM_RAWPOS_53 As Integer = &H2
 	Public Const STUDIO_ANIM_RAWROT_53 As Integer = &H4
 	Public Const STUDIO_ANIM_RAWSCALE_53 As Integer = &H8
-	Public Const STUDIO_ANIM_UNKFLAG_53 As Integer = &H10
+	Public Const STUDIO_ANIM_NOROT As Integer = &H10 ' this flag is used when the animation has no rotation data, it exists because it is not possible to check this as there are not separate flags for static/track rotation data
 
 
 	' Do not use union, because it will have to rely on size of a .NET Framework data type.

--- a/Crowbar/Core/GameModel/SourceModel52/SourceMdlFile52.vb
+++ b/Crowbar/Core/GameModel/SourceModel52/SourceMdlFile52.vb
@@ -1012,7 +1012,7 @@ Public Class SourceMdlFile52
 
 			anAnimationDesc.ikRuleZeroFrameOffset = Me.theInputFileReader.ReadInt32()
 
-			anAnimationDesc.compressedIkErrorOffset = Me.theInputFileReader.ReadInt32()
+			anAnimationDesc.frameMovementOffset = Me.theInputFileReader.ReadInt32()
 
 			For x As Integer = 0 To anAnimationDesc.unused1.Length - 1
 				anAnimationDesc.unused1(x) = Me.theInputFileReader.ReadInt32()
@@ -1039,6 +1039,8 @@ Public Class SourceMdlFile52
 
 			Me.ReadAnimationDescName(animInputFileStreamPosition, anAnimationDesc)
 			Me.ReadAnimationDescSpanData(animInputFileStreamPosition, anAnimationDesc)
+			Me.ReadMdlMovements(animInputFileStreamPosition, anAnimationDesc)
+			Me.ReadMdlFrameMovement(animInputFileStreamPosition, anAnimationDesc)
 
 			Me.theInputFileReader.BaseStream.Seek(inputFileStreamPosition, SeekOrigin.Begin)
 		Next
@@ -2175,6 +2177,49 @@ Public Class SourceMdlFile52
 			Return Me.theInputFileReader.BaseStream.Position - 1
 		End If
 	End Function
+
+	Protected Sub ReadMdlFrameMovement(ByVal animInputFileStreamPosition As Long, ByVal anAnimationDesc As SourceMdlAnimationDesc52)
+		If (anAnimationDesc.flags And SourceMdlAnimationDesc53.STUDIO_FRAMEMOVEMENT) > 0 And anAnimationDesc.frameMovementOffset > 0 Then
+			Dim fileOffsetStart As Long
+			Dim fileOffsetEnd As Long
+
+			Me.theInputFileReader.BaseStream.Seek(animInputFileStreamPosition + anAnimationDesc.frameMovementOffset, SeekOrigin.Begin)
+			fileOffsetStart = Me.theInputFileReader.BaseStream.Position
+
+			anAnimationDesc.theFrameMovement = New RSourceMdlFrameMovement
+
+			For j As Integer = 0 To 3
+				anAnimationDesc.theFrameMovement.scale(j) = Me.theInputFileReader.ReadSingle()
+			Next
+
+			For j As Integer = 0 To 3
+				anAnimationDesc.theFrameMovement.offset(j) = Me.theInputFileReader.ReadInt16()
+			Next
+
+			fileOffsetEnd = Me.theInputFileReader.BaseStream.Position - 1
+			Me.theMdlFileData.theFileSeekLog.Add(fileOffsetStart, fileOffsetEnd, "anAnimationDesc.theFrameMovement")
+
+			If anAnimationDesc.theFrameMovement.offset(0) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimXValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(0), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimXValues, "anAnimationDesc.theFrameMovement.theAnimXValues")
+			End If
+
+			If anAnimationDesc.theFrameMovement.offset(1) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimYValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(1), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimYValues, "anAnimationDesc.theFrameMovement.theAnimYValues")
+			End If
+
+			If anAnimationDesc.theFrameMovement.offset(2) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimZValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(2), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimZValues, "anAnimationDesc.theFrameMovement.theAnimZValues")
+			End If
+
+			If anAnimationDesc.theFrameMovement.offset(3) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimYawValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(3), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimYawValues, "anAnimationDesc.theFrameMovement.theAnimYawValues")
+			End If
+		End If
+	End Sub
 
 	Protected Function ReadLocalHierarchies(ByVal animInputFileStreamPosition As Long, ByVal anAnimationDesc As SourceMdlAnimationDesc52) As Long
 		If anAnimationDesc.localHierarchyCount > 0 Then

--- a/Crowbar/Core/GameModel/SourceModel52/SourceMdlFileData/RSourceMdlFrameMovement.vb
+++ b/Crowbar/Core/GameModel/SourceModel52/SourceMdlFileData/RSourceMdlFrameMovement.vb
@@ -1,0 +1,9 @@
+﻿Public Class RSourceMdlFrameMovement
+    Public scale(3) As Single
+    Public offset(3) As Short
+
+    Public theAnimXValues As List(Of SourceMdlAnimationValue)
+    Public theAnimYValues As List(Of SourceMdlAnimationValue)
+    Public theAnimZValues As List(Of SourceMdlAnimationValue)
+    Public theAnimYawValues As List(Of SourceMdlAnimationValue)
+End Class

--- a/Crowbar/Core/GameModel/SourceModel52/SourceMdlFileData/SourceMdlAnimationDesc52.vb
+++ b/Crowbar/Core/GameModel/SourceModel52/SourceMdlFileData/SourceMdlAnimationDesc52.vb
@@ -89,7 +89,7 @@ Public Class SourceMdlAnimationDesc52
 	'	mstudioikrulezeroframe_t *pIKRuleZeroFrame( int i ) const { if (ikrulezeroframeindex) return (mstudioikrulezeroframe_t *)(((byte *)this) + ikrulezeroframeindex) + i; else return NULL; };
 	Public ikRuleZeroFrameOffset As Integer
 
-	Public compressedIkErrorOffset As Integer
+	Public frameMovementOffset As Integer
 
 	'	int					unused1[5];			// remove as appropriate (and zero if loading older versions)	
 	Public unused1(3) As Integer
@@ -142,6 +142,7 @@ Public Class SourceMdlAnimationDesc52
 	Public theIkRules As List(Of SourceMdlIkRule)
 	Public theSections As List(Of SourceMdlAnimationSection)
 	Public theMovements As List(Of SourceMdlMovement)
+	Public theFrameMovement As RSourceMdlFrameMovement
 	Public theLocalHierarchies As List(Of SourceMdlLocalHierarchy)
 
 	Public theAnimIsLinkedToSequence As Boolean
@@ -200,5 +201,8 @@ Public Class SourceMdlAnimationDesc52
 	Public Const STUDIO_FRAMEANIM As Integer = &H40
 	Public Const STUDIO_NOFORCELOOP As Integer = &H8000
 	Public Const STUDIO_EVENT_CLIENT As Integer = &H10000
+	'------
+	'VERSION 52
+	Public Const STUDIO_FRAMEMOVEMENT As Integer = &H40000
 
 End Class

--- a/Crowbar/Core/GameModel/SourceModel52/SourceSmdFile52.vb
+++ b/Crowbar/Core/GameModel/SourceModel52/SourceSmdFile52.vb
@@ -409,57 +409,31 @@ Public Class SourceSmdFile52
 						boneFlag = aSectionOfAnimation.theBoneFlags(boneIndex)
 						If aSectionOfAnimation.theBoneConstantInfos IsNot Nothing Then
 							aBoneConstantInfo = aSectionOfAnimation.theBoneConstantInfos(boneIndex)
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_RAWROT) > 0 Then
+							If (boneFlag And SourceAniFrameAnim52.STUDIO_FRAME_RAWROT) > 0 Then
 								aFrameLine.rotation = MathModule.ToEulerAngles(aBoneConstantInfo.theConstantRawRot.quaternion)
 								aFrameLine.rotation.debug_text = "RAWROT"
 							End If
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_RAWPOS) > 0 Then
+							If (boneFlag And SourceAniFrameAnim52.STUDIO_FRAME_RAWPOS) > 0 Then
 								aFrameLine.position.x = aBoneConstantInfo.theConstantRawPos.x
 								aFrameLine.position.y = aBoneConstantInfo.theConstantRawPos.y
 								aFrameLine.position.z = aBoneConstantInfo.theConstantRawPos.z
 								aFrameLine.position.debug_text = "RAWPOS"
 							End If
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_CONST_POS2) > 0 Then
-								aFrameLine.position.x = aBoneConstantInfo.theConstantPosition2.x
-								aFrameLine.position.y = aBoneConstantInfo.theConstantPosition2.y
-								aFrameLine.position.z = aBoneConstantInfo.theConstantPosition2.z
-								aFrameLine.position.debug_text = "FRAME_CONST_POS2"
-							End If
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_CONST_ROT2) > 0 Then
-								aFrameLine.rotation = MathModule.ToEulerAngles(aBoneConstantInfo.theConstantRotation2.quaternion)
-								aFrameLine.rotation.debug_text = "FRAME_CONST_ROT2"
-							End If
+							' Scale would be read after this but we cannot use it
 						End If
 						If aSectionOfAnimation.theBoneFrameDataInfos IsNot Nothing Then
 							aBoneFrameDataInfo = aSectionOfAnimation.theBoneFrameDataInfos(sectionFrameIndex)(boneIndex)
-							'If (boneFlag And SourceAniFrameAnim.STUDIO_FRAME_ANIMROT) > 0 Then
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_FULLANIMPOS) > 0 Then
+							If (boneFlag And SourceAniFrameAnim52.STUDIO_FRAME_ANIMROT) > 0 Then
 								aFrameLine.rotation = MathModule.ToEulerAngles(aBoneFrameDataInfo.theAnimRotation.quaternion)
 								aFrameLine.rotation.debug_text = "ANIMROT"
 							End If
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_ANIMPOS) > 0 Then
+							If (boneFlag And SourceAniFrameAnim52.STUDIO_FRAME_ANIMPOS) > 0 Then
 								aFrameLine.position.x = aBoneFrameDataInfo.theAnimPosition.x
 								aFrameLine.position.y = aBoneFrameDataInfo.theAnimPosition.y
 								aFrameLine.position.z = aBoneFrameDataInfo.theAnimPosition.z
 								aFrameLine.position.debug_text = "ANIMPOS"
 							End If
-							'If (boneFlag And SourceAniFrameAnim.STUDIO_FRAME_FULLANIMPOS) > 0 Then
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_ANIMROT) > 0 Then
-								'aFrameLine.position.x = aBoneFrameDataInfo.theFullAnimPosition.x
-								'aFrameLine.position.y = aBoneFrameDataInfo.theFullAnimPosition.y
-								'aFrameLine.position.z = aBoneFrameDataInfo.theFullAnimPosition.z
-								aFrameLine.position.x = aBoneFrameDataInfo.theAnimPosition.x
-								aFrameLine.position.y = aBoneFrameDataInfo.theAnimPosition.y
-								aFrameLine.position.z = aBoneFrameDataInfo.theAnimPosition.z
-								aFrameLine.position.debug_text = "FULLANIMPOS"
-							End If
-							If (boneFlag And &H20) > 0 Then
-								Dim unknownFlagIsUsed As Integer = 4242
-							End If
-							If (boneFlag And SourceAniFrameAnim49.STUDIO_FRAME_ANIM_ROT2) > 0 Then
-								aFrameLine.rotation = MathModule.ToEulerAngles(aBoneFrameDataInfo.theAnimRotationUnknown.quaternion)
-								aFrameLine.rotation.debug_text = "FRAME_ANIM_ROT2"
-							End If
+							' Scale would be read after this but we cannot use it
 						End If
 					Next
 				Else

--- a/Crowbar/Core/GameModel/SourceModel52/SourceSmdFile52.vb
+++ b/Crowbar/Core/GameModel/SourceModel52/SourceSmdFile52.vb
@@ -480,7 +480,7 @@ Public Class SourceSmdFile52
 
 					Dim adjustedPosition As New SourceVector()
 					Dim adjustedRotation As New SourceVector()
-					Me.AdjustPositionAndRotationByPiecewiseMovement(frameIndex, boneIndex, anAnimationDesc.theMovements, aFrameLine.position, aFrameLine.rotation, adjustedPosition, adjustedRotation)
+					Me.AdjustPositionAndRotationByPiecewiseMovement(frameIndex, boneIndex, anAnimationDesc.theMovements, anAnimationDesc.theFrameMovement, aFrameLine.position, aFrameLine.rotation, adjustedPosition, adjustedRotation)
 					Me.AdjustPositionAndRotation(boneIndex, adjustedPosition, adjustedRotation, position, rotation)
 
 					line = "    "
@@ -590,7 +590,7 @@ Public Class SourceSmdFile52
 		End If
 	End Sub
 
-	Private Sub AdjustPositionAndRotationByPiecewiseMovement(ByVal frameIndex As Integer, ByVal boneIndex As Integer, ByVal movements As List(Of SourceMdlMovement), ByVal iPosition As SourceVector, ByVal iRotation As SourceVector, ByRef oPosition As SourceVector, ByRef oRotation As SourceVector)
+	Private Sub AdjustPositionAndRotationByPiecewiseMovement(ByVal frameIndex As Integer, ByVal boneIndex As Integer, ByVal movements As List(Of SourceMdlMovement), ByVal frameMovement As RSourceMdlFrameMovement, ByVal iPosition As SourceVector, ByVal iRotation As SourceVector, ByRef oPosition As SourceVector, ByRef oRotation As SourceVector)
 		Dim aBone As SourceMdlBone52
 		aBone = Me.theMdlFileData.theBones(boneIndex)
 
@@ -604,7 +604,7 @@ Public Class SourceSmdFile52
 		oRotation.debug_text = iRotation.debug_text
 
 		If aBone.parentBoneIndex = -1 Then
-			If movements IsNot Nothing AndAlso frameIndex > 0 Then
+			If frameIndex > 0 AndAlso (movements IsNot Nothing Or frameMovement IsNot Nothing) Then
 				Dim previousFrameIndex As Integer
 				Dim vecPos As SourceVector
 				Dim vecAngle As SourceVector
@@ -613,32 +613,60 @@ Public Class SourceSmdFile52
 				vecPos = New SourceVector()
 				vecAngle = New SourceVector()
 
-				For Each aMovement As SourceMdlMovement In movements
-					If frameIndex <= aMovement.endframeIndex Then
-						Dim f As Double
-						Dim d As Double
-						f = (frameIndex - previousFrameIndex) / (aMovement.endframeIndex - previousFrameIndex)
-						d = aMovement.v0 * f + 0.5 * (aMovement.v1 - aMovement.v0) * f * f
-						vecPos.x = vecPos.x + d * aMovement.vector.x
-						vecPos.y = vecPos.y + d * aMovement.vector.y
-						vecPos.z = vecPos.z + d * aMovement.vector.z
-						vecAngle.y = vecAngle.y * (1 - f) + MathModule.DegreesToRadians(aMovement.angle) * f
+				If movements IsNot Nothing Then
+					For Each aMovement As SourceMdlMovement In movements
+						If frameIndex <= aMovement.endframeIndex Then
+							Dim f As Double
+							Dim d As Double
+							f = (frameIndex - previousFrameIndex) / (aMovement.endframeIndex - previousFrameIndex)
+							d = aMovement.v0 * f + 0.5 * (aMovement.v1 - aMovement.v0) * f * f
+							vecPos.x = vecPos.x + d * aMovement.vector.x
+							vecPos.y = vecPos.y + d * aMovement.vector.y
+							vecPos.z = vecPos.z + d * aMovement.vector.z
+							vecAngle.y = vecAngle.y * (1 - f) + MathModule.DegreesToRadians(aMovement.angle) * f
 
-						Exit For
+							Exit For
+						Else
+							previousFrameIndex = aMovement.endframeIndex
+							vecPos.x = aMovement.position.x
+							vecPos.y = aMovement.position.y
+							vecPos.z = aMovement.position.z
+							vecAngle.y = MathModule.DegreesToRadians(aMovement.angle)
+						End If
+					Next
+				ElseIf frameMovement IsNot Nothing Then
+					If frameMovement.offset(0) > 0 Then
+						vecPos.x = Me.ExtractAnimValue(frameIndex, frameMovement.theAnimXValues, frameMovement.scale(0))
 					Else
-						previousFrameIndex = aMovement.endframeIndex
-						vecPos.x = aMovement.position.x
-						vecPos.y = aMovement.position.y
-						vecPos.z = aMovement.position.z
-						vecAngle.y = MathModule.DegreesToRadians(aMovement.angle)
+						vecPos.x = 0
 					End If
-				Next
+
+					If frameMovement.offset(1) > 0 Then
+						vecPos.y = Me.ExtractAnimValue(frameIndex, frameMovement.theAnimYValues, frameMovement.scale(1))
+					Else
+						vecPos.y = 0
+					End If
+
+					If frameMovement.offset(2) > 0 Then
+						vecPos.z = Me.ExtractAnimValue(frameIndex, frameMovement.theAnimZValues, frameMovement.scale(2))
+					Else
+						vecPos.z = 0
+					End If
+
+					If frameMovement.offset(3) > 0 Then
+						vecAngle.y = MathModule.DegreesToRadians(Me.ExtractAnimValue(frameIndex, frameMovement.theAnimYawValues, frameMovement.scale(3)))
+					Else
+						vecAngle.y = 0
+					End If
+				End If
 
 				'TEST: UNTESTED on MDL v52 - Works in MDL v49 for translation and maybe rotation on Z, but ignores other axis rotations because the above does not work for rotations.
 				oPosition.x = iPosition.x + vecPos.x
 				oPosition.y = iPosition.y + vecPos.y
 				oPosition.z = iPosition.z + vecPos.z
 				oRotation.z = iRotation.z + vecAngle.y
+				'ElseIf 
+
 			End If
 		End If
 	End Sub

--- a/Crowbar/Core/GameModel/SourceModel53/SourceMdlFile53.vb
+++ b/Crowbar/Core/GameModel/SourceModel53/SourceMdlFile53.vb
@@ -962,7 +962,7 @@ Public Class SourceMdlFile53
 				anAnimationDesc.movementCount = Me.theInputFileReader.ReadInt32()
 				anAnimationDesc.movementOffset = Me.theInputFileReader.ReadInt32()
 
-				anAnimationDesc.compressedIkErrorOffset = Me.theInputFileReader.ReadInt32()
+				anAnimationDesc.frameMovementOffset = Me.theInputFileReader.ReadInt32()
 
 				anAnimationDesc.animOffset = Me.theInputFileReader.ReadInt32()
 				anAnimationDesc.ikRuleCount = Me.theInputFileReader.ReadInt32()
@@ -988,6 +988,8 @@ Public Class SourceMdlFile53
 
 				Me.ReadAnimationDescName(animInputFileStreamPosition, anAnimationDesc)
 				'Me.ReadAnimationDescSpanData(animInputFileStreamPosition, anAnimationDesc)
+				Me.ReadMdlMovements(animInputFileStreamPosition, anAnimationDesc)
+				Me.ReadMdlFrameMovement(animInputFileStreamPosition, anAnimationDesc)
 
 				Me.theInputFileReader.BaseStream.Seek(inputFileStreamPosition, SeekOrigin.Begin)
 			Next
@@ -1454,7 +1456,7 @@ Public Class SourceMdlFile53
 	End Sub
 
 	Private Sub ReadMdlAnimationAnimValues(ByVal anAnimation As SourceMdlAnimation, ByVal rotValuePointerInputFileStreamPosition As Long, ByVal posValuePointerInputFileStreamPosition As Long, ByVal scaleValuePointerInputFileStreamPosition As Long, ByVal frameCount As Integer, ByVal lastSectionIsBeingRead As Boolean)
-		If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_RAWROT_53) = 0 Then
+		If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_RAWROT_53) = 0 AndAlso (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_NOROT) = 0 Then
 			anAnimation.theRotV = New SourceMdlAnimationValuePointer()
 			If anAnimation.theRot64bits.XOffset > 0 Then
 				anAnimation.theRotV.theAnimXValues = New List(Of SourceMdlAnimationValue)()
@@ -1966,6 +1968,49 @@ Public Class SourceMdlFile53
 
 			fileOffsetEnd = Me.theInputFileReader.BaseStream.Position - 1
 			Me.theMdlFileData.theFileSeekLog.Add(fileOffsetStart, fileOffsetEnd, "anAnimationDesc.theMovements")
+		End If
+	End Sub
+
+	Protected Sub ReadMdlFrameMovement(ByVal animInputFileStreamPosition As Long, ByVal anAnimationDesc As SourceMdlAnimationDesc53)
+		If (anAnimationDesc.flags And SourceMdlAnimationDesc53.STUDIO_FRAMEMOVEMENT) > 0 And anAnimationDesc.frameMovementOffset > 0 Then
+			Dim fileOffsetStart As Long
+			Dim fileOffsetEnd As Long
+
+			Me.theInputFileReader.BaseStream.Seek(animInputFileStreamPosition + anAnimationDesc.frameMovementOffset, SeekOrigin.Begin)
+			fileOffsetStart = Me.theInputFileReader.BaseStream.Position
+
+			anAnimationDesc.theFrameMovement = New RSourceMdlFrameMovement
+
+			For j As Integer = 0 To 3
+				anAnimationDesc.theFrameMovement.scale(j) = Me.theInputFileReader.ReadSingle()
+			Next
+
+			For j As Integer = 0 To 3
+				anAnimationDesc.theFrameMovement.offset(j) = Me.theInputFileReader.ReadInt16()
+			Next
+
+			fileOffsetEnd = Me.theInputFileReader.BaseStream.Position - 1
+			Me.theMdlFileData.theFileSeekLog.Add(fileOffsetStart, fileOffsetEnd, "anAnimationDesc.theFrameMovement")
+
+			If anAnimationDesc.theFrameMovement.offset(0) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimXValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(0), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimXValues, "anAnimationDesc.theFrameMovement.theAnimXValues")
+			End If
+
+			If anAnimationDesc.theFrameMovement.offset(1) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimYValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(1), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimYValues, "anAnimationDesc.theFrameMovement.theAnimYValues")
+			End If
+
+			If anAnimationDesc.theFrameMovement.offset(2) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimZValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(2), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimZValues, "anAnimationDesc.theFrameMovement.theAnimZValues")
+			End If
+
+			If anAnimationDesc.theFrameMovement.offset(3) > 0 Then
+				anAnimationDesc.theFrameMovement.theAnimYawValues = New List(Of SourceMdlAnimationValue)()
+				Me.ReadMdlAnimValues(fileOffsetStart + anAnimationDesc.theFrameMovement.offset(3), anAnimationDesc.frameCount, True, anAnimationDesc.theFrameMovement.theAnimYawValues, "anAnimationDesc.theFrameMovement.theAnimYawValues")
+			End If
 		End If
 	End Sub
 

--- a/Crowbar/Core/GameModel/SourceModel53/SourceMdlFileData/SourceMdlAnimationDesc53.vb
+++ b/Crowbar/Core/GameModel/SourceModel53/SourceMdlFileData/SourceMdlAnimationDesc53.vb
@@ -95,7 +95,7 @@ Public Class SourceMdlAnimationDesc53
 	'	int					animblock;
 	'Public animBlock As Integer
 
-	Public compressedIkErrorOffset As Integer
+	Public frameMovementOffset As Integer
 
 	'	int					animindex;	 // non-zero when anim data isn't in sections
 	Public animOffset As Integer
@@ -142,6 +142,7 @@ Public Class SourceMdlAnimationDesc53
 	Public theIkRules As List(Of SourceMdlIkRule53)
 	Public theSections As List(Of SourceMdlAnimationSection)
 	Public theMovements As List(Of SourceMdlMovement)
+	Public theFrameMovement As RSourceMdlFrameMovement
 	Public theLocalHierarchies As List(Of SourceMdlLocalHierarchy)
 
 	Public theAnimIsLinkedToSequence As Boolean
@@ -200,5 +201,8 @@ Public Class SourceMdlAnimationDesc53
 	Public Const STUDIO_FRAMEANIM As Integer = &H40
 	Public Const STUDIO_NOFORCELOOP As Integer = &H8000
 	Public Const STUDIO_EVENT_CLIENT As Integer = &H10000
+	'------
+	'VERSION 52
+	Public Const STUDIO_FRAMEMOVEMENT As Integer = &H40000
 
 End Class

--- a/Crowbar/Core/GameModel/SourceModel53/SourceSmdFile53.vb
+++ b/Crowbar/Core/GameModel/SourceModel53/SourceSmdFile53.vb
@@ -1584,7 +1584,7 @@ Public Class SourceSmdFile53
 			Return angleVector
 		End If
 
-		If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_RAWROT_53) > 0 Then
+		If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_NOROT) > 0 Then
 			If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_DELTA_53) > 0 Then
 				angleVector.x = 0
 				angleVector.y = 0
@@ -1634,15 +1634,15 @@ Public Class SourceSmdFile53
 				angleVector.debug_text += "+bone"
 			End If
 
-		Else
-			angleVector.x = aBone.rotation.x
-			angleVector.y = aBone.rotation.y
-			angleVector.z = aBone.rotation.z
-			rotationQuat.x = 0
-			rotationQuat.y = 0
-			rotationQuat.z = 0
-			rotationQuat.w = 0
-			angleVector.debug_text = "bone"
+			'Else
+			'	angleVector.x = aBone.rotation.x
+			'	angleVector.y = aBone.rotation.y
+			'	angleVector.z = aBone.rotation.z
+			'	rotationQuat.x = 0
+			'	rotationQuat.y = 0
+			'	rotationQuat.z = 0
+			'	rotationQuat.w = 0
+			'	angleVector.debug_text = "bone"
 		End If
 		'Catch ex As Exception
 		'Dim debug As Integer = 4242
@@ -1715,19 +1715,12 @@ Public Class SourceSmdFile53
 		Dim pos As New SourceVector()
 
 		If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_RAWPOS_53) > 0 Then
-			If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_DELTA_53) > 0 Then
-				pos.x = 0
-				pos.y = 0
-				pos.z = 0
-				pos.debug_text = "delta"
-				Return pos
-			Else
-				pos.x = anAnimation.PosX.TheFloatValue
-				pos.y = anAnimation.PosY.TheFloatValue
-				pos.z = anAnimation.PosZ.TheFloatValue
-				pos.debug_text = "raw"
-				Return pos
-			End If
+			pos.x = anAnimation.PosX.TheFloatValue
+			pos.y = anAnimation.PosY.TheFloatValue
+			pos.z = anAnimation.PosZ.TheFloatValue
+
+			pos.debug_text = "raw"
+			Return pos
 		End If
 
 		If anAnimation.thePosV IsNot Nothing Then
@@ -1753,19 +1746,19 @@ Public Class SourceSmdFile53
 
 			pos.debug_text = "anim"
 
-			If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_DELTA_53) = 0 Then
-				pos.x += aBone.position.x
-				pos.y += aBone.position.y
-				pos.z += aBone.position.z
-				pos.debug_text += "+bone"
-			End If
-
 			' never used from what I have seen	
-		Else
-			pos.x = aBone.position.x
-			pos.y = aBone.position.y
-			pos.z = aBone.position.z
-			pos.debug_text = "bone"
+			'Else
+			'	pos.x = aBone.position.x
+			'	pos.y = aBone.position.y
+			'	pos.z = aBone.position.z
+			'	pos.debug_text = "bone"
+		End If
+
+		If (anAnimation.flags And SourceMdlAnimation.STUDIO_ANIM_DELTA_53) = 0 Then
+			pos.x += aBone.position.x
+			pos.y += aBone.position.y
+			pos.z += aBone.position.z
+			pos.debug_text += "+bone"
 		End If
 
 		Return pos

--- a/Crowbar/Crowbar.vbproj
+++ b/Crowbar/Crowbar.vbproj
@@ -13,7 +13,7 @@
     <MyType>WindowsFormsWithCustomSubMain</MyType>
     <OptionStrict>On</OptionStrict>
     <ApplicationIcon>Resources\crowbar_icon.ico</ApplicationIcon>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileUpgradeFlags>
     </FileUpgradeFlags>
     <UpgradeBackupLocation>
@@ -128,6 +128,7 @@
     <Compile Include="Core\GameModel\CompiledFiles\VvdFile\VvdFile04\SourceVvdExtraData04.vb" />
     <Compile Include="Core\GameModel\SourceCommon\SourceMdlFileData\SourceMdlAnimTag.vb" />
     <Compile Include="Core\GameModel\SourceGlobal\SourceTextureCoordinates.vb" />
+    <Compile Include="Core\GameModel\SourceModel52\SourceMdlFileData\RSourceMdlFrameMovement.vb" />
     <Compile Include="Core\GameModel\SourceModel52\SourceMdlFileData\RSourcePerTriCollisionHeader52.vb" />
     <Compile Include="Core\GameModel\SourceModel52\SourceMdlFileData\SourceMdlBone52.vb" />
     <Compile Include="Core\GameModel\SourceModel53\SourceMdlFileData\RSourceRuiHeader53.vb" />

--- a/CrowbarLauncher/CrowbarLauncher.vbproj
+++ b/CrowbarLauncher/CrowbarLauncher.vbproj
@@ -11,7 +11,7 @@
     <AssemblyName>CrowbarLauncher</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>WindowsFormsWithCustomSubMain</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/CrowbarSteamPipe/CrowbarSteamPipe.vbproj
+++ b/CrowbarSteamPipe/CrowbarSteamPipe.vbproj
@@ -11,7 +11,7 @@
     <AssemblyName>CrowbarSteamPipe</AssemblyName>
     <FileAlignment>512</FileAlignment>
     <MyType>Console</MyType>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <Deterministic>true</Deterministic>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">


### PR DESCRIPTION
-added support for respawns new style of movements called "framemovements", these use rle style animation tracks for values.
-added v52 rle animation flags for scale (these are mostly for future reference).
-updated flags v53 uses for rle animations, final flag '0x10' has been found an acts as a check if the model has no anim ptr or quat.
-fixes some reading of v52 frame anims, removing support for non existent data types.